### PR TITLE
Remove tabIndex

### DIFF
--- a/OrganizationSearch/OrganizationSearch.js
+++ b/OrganizationSearch/OrganizationSearch.js
@@ -55,7 +55,6 @@ class OrganizationSearch extends Component {
               marginBottom0={marginBottom0}
               onClick={this.openModal}
               ariaLabel={ariaLabel}
-              tabIndex="-1"
             >
               {this.props.searchLabel ? this.props.searchLabel : <Icon icon="search" color="#fff" />}
             </Button>


### PR DESCRIPTION
Setting `tabIndex="-1"` makes the button inaccessible for keyboard users.