### PR TITLE
Return focus to the trigger button after lookup modal is closed, refs…

### DIFF
--- a/OrganizationSearch/OrganizationSearch.js
+++ b/OrganizationSearch/OrganizationSearch.js
@@ -104,6 +104,7 @@ OrganizationSearch.propTypes = {
     marginBottom0: PropTypes.bool,
   }),
   id: PropTypes.string,
+  renderTrigger: PropTypes.func,
   searchLabel: PropTypes.node,
   searchButtonStyle: PropTypes.string,
   marginBottom0: PropTypes.bool,

--- a/OrganizationSearch/OrganizationSearch.js
+++ b/OrganizationSearch/OrganizationSearch.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Button, Icon } from '@folio/stripes/components';
 import className from 'classnames';
+import contains from 'dom-helpers/query/contains';
 
 import css from './OrganizationSearch.css';
 import OrganizationSearchModal from './OrganizationSearchModal';
@@ -17,6 +18,8 @@ class OrganizationSearch extends Component {
 
     this.openModal = this.openModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
+    this.modalTrigger = React.createRef();
+    this.modalRef = React.createRef();
   }
 
   getStyle() {
@@ -38,29 +41,49 @@ class OrganizationSearch extends Component {
   closeModal() {
     this.setState({
       openModal: false,
+    }, () => {
+      if (this.modalRef.current && this.modalTrigger.current) {
+        if (contains(this.modalRef.current, document.activeElement)) {
+          this.modalTrigger.current.focus();
+        }
+      }
+    });
+  }
+
+  renderTriggerButton() {
+    const {
+      renderTrigger,
+    } = this.props;
+
+    return renderTrigger({
+      buttonRef: this.modalTrigger,
+      onClick: this.openModal,
     });
   }
 
   render() {
-    const { id, buttonProps: { marginBottom0 } } = this.props;
+    const { id, buttonProps: { marginBottom0 }, renderTrigger } = this.props;
 
     return (
       <div className={this.getStyle()}>
-        <FormattedMessage id="ui-plugin-find-organization.searchButton.title">
-          {ariaLabel => (
-            <Button
-              id={id}
-              key="searchButton"
-              buttonStyle={this.props.searchButtonStyle}
-              marginBottom0={marginBottom0}
-              onClick={this.openModal}
-              aria-label={ariaLabel}
-            >
-              {this.props.searchLabel ? this.props.searchLabel : <Icon icon="search" color="#fff" />}
-            </Button>
-          )}
-        </FormattedMessage>
+        {renderTrigger ?
+          this.renderTriggerButton() :
+          <FormattedMessage id="ui-plugin-find-organization.searchButton.title">
+            {ariaLabel => (
+              <Button
+                id={id}
+                key="searchButton"
+                buttonStyle={this.props.searchButtonStyle}
+                marginBottom0={marginBottom0}
+                onClick={this.openModal}
+                aria-label={ariaLabel}
+              >
+                {this.props.searchLabel ? this.props.searchLabel : <Icon icon="search" color="#fff" />}
+              </Button>
+            )}
+          </FormattedMessage>}
         <OrganizationSearchModal
+          modalRef={this.modalRef}
           openWhen={this.state.openModal}
           closeCB={this.closeModal}
           {...this.props}
@@ -73,6 +96,7 @@ class OrganizationSearch extends Component {
 OrganizationSearch.defaultProps = {
   searchButtonStyle: 'primary noRightRadius',
   id: 'clickable-plugin-find-organization',
+  buttonProps: {},
 };
 
 OrganizationSearch.propTypes = {

--- a/OrganizationSearch/OrganizationSearchModal.js
+++ b/OrganizationSearch/OrganizationSearchModal.js
@@ -13,6 +13,7 @@ export default class OrganizationSearchModal extends Component {
     }).isRequired,
     selectVendor: PropTypes.func.isRequired,
     closeCB: PropTypes.func.isRequired,
+    modalRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
     onCloseModal: PropTypes.func,
     openWhen: PropTypes.bool,
     dataKey: PropTypes.string,
@@ -29,6 +30,7 @@ export default class OrganizationSearchModal extends Component {
       error: null,
     };
 
+    this.modalRef = props.modalRef || React.createRef();
     this.closeModal = this.closeModal.bind(this);
     this.passVendorOut = this.passVendorOut.bind(this);
   }
@@ -60,6 +62,8 @@ export default class OrganizationSearchModal extends Component {
         open={this.props.openWhen}
         label={<FormattedMessage id="ui-plugin-find-organization.modal.label" />}
         contentClass={css.organizationSearchModalContent}
+        enforceFocus={false}
+        ref={this.modalRef}
         dismissible
       >
         <div className={css.organizationSearchModal}>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@folio/organizations": "^1.2.0",
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "dom-helpers":"^3.4.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.7.0",


### PR DESCRIPTION
… UIPFO-6, ERM-620

https://issues.folio.org/browse/UIPFO-6
https://issues.folio.org/browse/ERM-620

Also added the renderTrigger optional render function for the button to open the find organization modal. This function can be used to pass back the ref for the trigger button back to the parent to focus it, for example: whenever a new field is rendered as a part of a repeatableField

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
