### PR TITLE
UIPFO-53 ECS - Accept `tenantId` prop to search entries in the specified tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (5.2.0 IN PROGRESS)
 
+* ECS - Accept `tenantId` prop to search entries in the specified tenant. Refs UIPFO-53.
+
 ## [5.1.1](https://github.com/folio-org/ui-plugin-find-organization/tree/v5.1.1) (2024-04-18)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-organization/compare/v5.1.0...v5.1.1)
 

--- a/OrganizationSearch/FindOrganization.js
+++ b/OrganizationSearch/FindOrganization.js
@@ -35,9 +35,10 @@ const resultsFormatter = {
 };
 
 export const FindOrganization = ({
-  isMultiSelect,
+  isMultiSelect = false,
   selectVendor,
-  visibleFilters,
+  tenantId,
+  visibleFilters = VISIBLE_FILTERS,
   ...rest
 }) => {
   const stripes = useStripes();
@@ -47,7 +48,7 @@ export const FindOrganization = ({
   const [searchParams, setSearchParams] = useState({});
   const [isLoading, setIsLoading] = useState(false);
 
-  const { fetchOrganizations } = useOrganizations();
+  const { fetchOrganizations } = useOrganizations({ tenantId });
 
   const searchableIndexes = useMemo(() => getSearchableIndexes(stripes), [stripes]);
 
@@ -83,10 +84,11 @@ export const FindOrganization = ({
       <OrganizationsListFilter
         activeFilters={activeFilters}
         applyFilters={applyFilters}
+        tenantId={tenantId}
         visibleFilters={visibleFilters}
       />
     );
-  }, [visibleFilters]);
+  }, [tenantId, visibleFilters]);
 
   const selectRecord = useCallback((vendors) => {
     selectVendor(isMultiSelect ? vendors : vendors[0]);
@@ -116,14 +118,10 @@ export const FindOrganization = ({
 };
 
 FindOrganization.propTypes = {
-  selectVendor: PropTypes.func.isRequired,
   isMultiSelect: PropTypes.bool,
+  selectVendor: PropTypes.func.isRequired,
+  tenantId: PropTypes.string,
   visibleFilters: PropTypes.arrayOf(
     PropTypes.oneOf(VISIBLE_FILTERS),
   ),
-};
-
-FindOrganization.defaultProps = {
-  isMultiSelect: false,
-  visibleFilters: VISIBLE_FILTERS,
 };

--- a/OrganizationSearch/OrganizationsListFilter/OrganizationsListFilter.js
+++ b/OrganizationSearch/OrganizationsListFilter/OrganizationsListFilter.js
@@ -27,12 +27,10 @@ const OrganizationsListFilter = ({
   activeFilters,
   applyFilters,
   disabled,
-  visibleFilters,
+  tenantId,
+  visibleFilters = VISIBLE_FILTERS,
 }) => {
-  const adaptedApplyFilters = useCallback(
-    applyFiltersAdapter(applyFilters),
-    [applyFilters],
-  );
+  const adaptedApplyFilters = useCallback((data) => applyFiltersAdapter(applyFilters)(data), [applyFilters]);
 
   const availableFilters = useMemo(() => [
     {
@@ -58,6 +56,7 @@ const OrganizationsListFilter = ({
           id={`org-filter-${FILTERS.TYPES}`}
           name={FILTERS.TYPES}
           onChange={adaptedApplyFilters}
+          tenantId={tenantId}
         />
       ),
     },
@@ -70,6 +69,7 @@ const OrganizationsListFilter = ({
           id={FILTERS.TAGS}
           name={FILTERS.TAGS}
           onChange={adaptedApplyFilters}
+          tenantId={tenantId}
         />
       ),
     },
@@ -147,6 +147,7 @@ const OrganizationsListFilter = ({
           disabled={disabled}
           name={FILTERS.ACQUISITIONS_UNIT}
           onChange={adaptedApplyFilters}
+          tenantId={tenantId}
         />
       ),
     },
@@ -160,6 +161,7 @@ const OrganizationsListFilter = ({
           name={FILTERS.CREATED_BY}
           onChange={adaptedApplyFilters}
           disabled={disabled}
+          tenantId={tenantId}
         />
       ),
     },
@@ -186,6 +188,7 @@ const OrganizationsListFilter = ({
           name={FILTERS.UPDATED_BY}
           onChange={adaptedApplyFilters}
           disabled={disabled}
+          tenantId={tenantId}
         />
       ),
     },
@@ -202,7 +205,7 @@ const OrganizationsListFilter = ({
         />
       ),
     },
-  ], [disabled, activeFilters, adaptedApplyFilters]);
+  ], [activeFilters, adaptedApplyFilters, disabled, tenantId]);
 
   const renderFilters = useCallback(() => {
     return availableFilters
@@ -225,11 +228,8 @@ OrganizationsListFilter.propTypes = {
   activeFilters: PropTypes.object.isRequired,
   applyFilters: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  tenantId: PropTypes.string,
   visibleFilters: PropTypes.arrayOf(PropTypes.string),
-};
-
-OrganizationsListFilter.defaultProps = {
-  visibleFilters: VISIBLE_FILTERS,
 };
 
 export default OrganizationsListFilter;

--- a/OrganizationSearch/OrganizationsListFilter/OrganizationsListFilter.test.js
+++ b/OrganizationSearch/OrganizationsListFilter/OrganizationsListFilter.test.js
@@ -6,9 +6,16 @@ import { FILTERS } from '../constants';
 import { useTypes } from '../hooks';
 import OrganizationsListFilter from './OrganizationsListFilter';
 
+jest.mock('@folio/stripes-acq-components/lib/hooks', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components/lib/hooks'),
+  useAcquisitionUnits: jest.fn(() => ({ acquisitionsUnits: [] })),
+  useTagsConfigs: jest.fn(() => ({ configs: [], isFetched: true })),
+  useTags: jest.fn(() => ({ tags: [] })),
+  useUser: jest.fn(() => ({})),
+}));
 jest.mock('../hooks', () => ({
   ...jest.requireActual('../hooks'),
-  useTypes: jest.fn(),
+  useTypes: jest.fn(() => ({ organizationTypes: [] })),
 }));
 
 const renderOrganizationsListFilter = (props) => (render(
@@ -21,18 +28,20 @@ const renderOrganizationsListFilter = (props) => (render(
 
 describe('OrganizationsListFilter component', () => {
   beforeEach(() => {
-    useTypes.mockClear().mockReturnValue({ organizationTypes });
+    useTypes
+      .mockClear()
+      .mockReturnValue({ organizationTypes });
   });
 
   it('should display filters', () => {
     const { getByText } = renderOrganizationsListFilter();
 
-    expect(getByText('ui-organizations.filterConfig.vendorStatus')).toBeDefined();
-    expect(getByText('ui-organizations.filterConfig.isVendor')).toBeDefined();
-    expect(getByText('ui-organizations.filterConfig.isDonor')).toBeDefined();
-    expect(getByText('ui-organizations.filterConfig.country')).toBeDefined();
-    expect(getByText('ui-organizations.filterConfig.languages')).toBeDefined();
-    expect(getByText('ui-organizations.filterConfig.paymentMethod')).toBeDefined();
+    expect(getByText('ui-organizations.filterConfig.vendorStatus')).toBeInTheDocument();
+    expect(getByText('ui-organizations.filterConfig.isVendor')).toBeInTheDocument();
+    expect(getByText('ui-organizations.filterConfig.isDonor')).toBeInTheDocument();
+    expect(getByText('ui-organizations.filterConfig.country')).toBeInTheDocument();
+    expect(getByText('ui-organizations.filterConfig.languages')).toBeInTheDocument();
+    expect(getByText('ui-organizations.filterConfig.paymentMethod')).toBeInTheDocument();
   });
 
   it('should display donor-related filters', () => {
@@ -44,9 +53,9 @@ describe('OrganizationsListFilter component', () => {
       ],
     });
 
-    expect(getByText('stripes-acq-components.filter.tags')).toBeDefined();
-    expect(getByText('ui-organizations.filterConfig.isVendor')).toBeDefined();
-    expect(getByText('ui-organizations.filterConfig.types')).toBeDefined();
+    expect(getByText('stripes-acq-components.filter.tags')).toBeInTheDocument();
+    expect(getByText('ui-organizations.filterConfig.isVendor')).toBeInTheDocument();
+    expect(getByText('ui-organizations.filterConfig.types')).toBeInTheDocument();
 
     expect(queryByText('ui-organizations.filterConfig.vendorStatus')).toBeNull();
     expect(queryByText('ui-organizations.filterConfig.isDonor')).toBeNull();

--- a/OrganizationSearch/OrganizationsListFilter/TypeFilter/TypeFilter.js
+++ b/OrganizationSearch/OrganizationsListFilter/TypeFilter/TypeFilter.js
@@ -7,14 +7,15 @@ import { useTypes } from '../../hooks';
 
 export const TypeFilter = ({
   activeFilters,
-  closedByDefault,
-  disabled,
+  closedByDefault = true,
+  disabled = false,
   id,
-  labelId,
+  labelId = 'ui-organizations.filterConfig.types',
   name,
   onChange,
+  tenantId,
 }) => {
-  const { organizationTypes } = useTypes();
+  const { organizationTypes } = useTypes({ tenantId });
 
   const types = organizationTypes?.map(type => ({
     label: type.name,
@@ -52,10 +53,5 @@ TypeFilter.propTypes = {
   labelId: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-};
-
-TypeFilter.defaultProps = {
-  closedByDefault: true,
-  disabled: false,
-  labelId: 'ui-organizations.filterConfig.types',
+  tenantId: PropTypes.string,
 };

--- a/OrganizationSearch/hooks/useOrganizations/useOrganizations.js
+++ b/OrganizationSearch/hooks/useOrganizations/useOrganizations.js
@@ -21,8 +21,10 @@ import {
   getKeywordQuery,
 } from '../../OrganizationsSearchConfig';
 
-export const useOrganizations = () => {
-  const ky = useOkapiKy();
+export const useOrganizations = (options = {}) => {
+  const { tenantId } = options;
+
+  const ky = useOkapiKy({ tenant: tenantId });
   const stripes = useStripes();
 
   const fetchOrganizations = useCallback(async ({

--- a/OrganizationSearch/hooks/useTypes/useTypes.js
+++ b/OrganizationSearch/hooks/useTypes/useTypes.js
@@ -5,8 +5,14 @@ import { LIMIT_MAX } from '@folio/stripes-acq-components';
 
 const DEFAULT_DATA = [];
 
-export const useTypes = () => {
-  const ky = useOkapiKy();
+export const useTypes = (options = {}) => {
+  const {
+    enabled = true,
+    tenantId,
+    ...queryOptions
+  } = options;
+
+  const ky = useOkapiKy({ tenant: tenantId });
 
   const searchParams = {
     limit: LIMIT_MAX,
@@ -16,10 +22,12 @@ export const useTypes = () => {
   const {
     isLoading,
     data,
-  } = useQuery(
-    ['organization-types'],
-    () => ky.get('organizations-storage/organization-types', { searchParams }).json(),
-  );
+  } = useQuery({
+    queryKey: ['organization-types', tenantId],
+    queryFn: ({ signal }) => ky.get('organizations-storage/organization-types', { searchParams, signal }).json(),
+    enabled,
+    ...queryOptions,
+  });
 
   return ({
     organizationTypes: data?.organizationTypes ?? DEFAULT_DATA,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIPFO-53

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

Ensure all places in the plugin that work with network requests are provided with the `tenantId` parameter, to specify the tenant in which the search is conducted.

## Screenshots

https://github.com/user-attachments/assets/549c3f8f-892a-41fb-b207-9518e62256b0


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
